### PR TITLE
Robot doc changes for ScreenCast DBUS API.

### DIFF
--- a/src/java.desktop/share/classes/java/awt/peer/RobotPeer.java
+++ b/src/java.desktop/share/classes/java/awt/peer/RobotPeer.java
@@ -129,7 +129,8 @@ public interface RobotPeer
     }
 
     /**
-     * placeholder
+     * Resets the stored screen data capture permission for a set of screens.
+     * Is a no-op if not supported by the platform.
      */
     default void resetScreenCapturePermission() {}
 }


### PR DESCRIPTION
Here are suggested changes to the robot documentation related to the ScreenCast DBUS API.

I still haven't decided where to put the description of the new system properties(`awt.robot.screencastEnabled`, `awt.robot.screencastDebug`), because they are too Linux specific.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/wakefield.git pull/4/head:pull/4` \
`$ git checkout pull/4`

Update a local copy of the PR: \
`$ git checkout pull/4` \
`$ git pull https://git.openjdk.org/wakefield.git pull/4/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4`

View PR using the GUI difftool: \
`$ git pr show -t 4`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/wakefield/pull/4.diff">https://git.openjdk.org/wakefield/pull/4.diff</a>

</details>
