### PR TITLE
Fix WLClipboard NPE

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/wl/WLClipboard.java
+++ b/src/java.desktop/unix/classes/sun/awt/wl/WLClipboard.java
@@ -253,7 +253,7 @@ public final class WLClipboard extends SunClipboard {
     }
 
     /**
-     * @return formats the current clipboard is available in; could be null
+     * @return formats the current clipboard is available in; could be empty
      */
     @Override
     protected long[] getClipboardFormats() {
@@ -265,7 +265,7 @@ public final class WLClipboard extends SunClipboard {
                 }
                 return res;
             } else {
-                return null;
+                return new long[0];
             }
         }
     }


### PR DESCRIPTION
getClipboardFormats is not supposed to return null according to the superclass documentation, this caused a NPE when reading the clipboard sometimes (at least on KDE).

(There's a separate issue with the clipboard; currently every call to WLClipboard::getClipboardData reads the data from the file descriptor provided by wl_data_offer.receive(), but it's only supposed to be read once until EOF and then closed according to the specification. On KDE, this results in getClipboardData() blocking if the clipboard contents change and the Java window is not focused, and is part of the cause of the deadlock fixed in bb75b33.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewers
 * [Maxim Kartashev](https://openjdk.org/census#mkartashev) (@mkartashev - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/wakefield.git pull/9/head:pull/9` \
`$ git checkout pull/9`

Update a local copy of the PR: \
`$ git checkout pull/9` \
`$ git pull https://git.openjdk.org/wakefield.git pull/9/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9`

View PR using the GUI difftool: \
`$ git pr show -t 9`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/wakefield/pull/9.diff">https://git.openjdk.org/wakefield/pull/9.diff</a>

</details>
